### PR TITLE
Fixed parsing error in Giratina's poser

### DIFF
--- a/common/src/main/resources/assets/cobblemon/bedrock/pokemon/posers/0487_giratina/giratina.json
+++ b/common/src/main/resources/assets/cobblemon/bedrock/pokemon/posers/0487_giratina/giratina.json
@@ -69,7 +69,7 @@
       ],
       "animations": [
         "q.look('head')",
-        "q.bedrock('giratina', 'air_fly'')"
+        "q.bedrock('giratina', 'air_fly')"
       ]
     },
     "swim": {


### PR DESCRIPTION
Poser had a double `'` causing a note in the log each time it gets loaded.

<img width="658" height="22" alt="image" src="https://github.com/user-attachments/assets/64b9b3f4-489a-4dc5-9a8b-de9929be9832" />
