### PR TITLE
Reduced Kyogre's size & hitbox, removed being able to fly(?)

### DIFF
--- a/common/src/main/resources/data/cobblemon/species_additions/kyogre.json
+++ b/common/src/main/resources/data/cobblemon/species_additions/kyogre.json
@@ -25,9 +25,9 @@
       }
     ]
   },
-  "baseScale": 1,
+  "baseScale": 0.8,
   "hitbox": {
-    "width": 10,
+    "width": 5.8,
     "height": 2.1,
     "fixed": false
   },
@@ -43,8 +43,7 @@
         "swimSpeed": 1.2,
         "canSwimInWater": true,
         "canBreatheUnderwater": true
-      },
-      "canFly": true
+      }
     }
   }
 }


### PR DESCRIPTION
Apparently Kyogre was able to fly (it was at least coded as canFly true but it never could so might as well remove it)
Also reduced its size (it was way too big) and hitbox because that led to some issues with it spawning, which might be a problem for addons trying to add a natural spawn to it.