### PR TITLE
Fix model registry reload race

### DIFF
--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/mixin/client/ItemRendererMixin.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/mixin/client/ItemRendererMixin.java
@@ -32,7 +32,7 @@ public abstract class ItemRendererMixin {
             argsOnly = true
     )
     public BakedModel modifyModel(BakedModel bakedModel, @Local(argsOnly = true) ItemStack stack, @Local(argsOnly = true) ItemDisplayContext renderMode) {
-        ItemRenderingCodec itemRenderingCodec = ItemRenderingLoader.REGISTRY.getOrDefault(BuiltInRegistries.ITEM.getKey(stack.getItem()), null);
+        ItemRenderingCodec itemRenderingCodec = ItemRenderingLoader.get(BuiltInRegistries.ITEM.getKey(stack.getItem()));
 
         if (itemRenderingCodec != null) {
             PerspectivesCodec perspectives = itemRenderingCodec.perspectivesCodec();
@@ -64,7 +64,7 @@ public abstract class ItemRendererMixin {
             ordinal = 1
     )
     public BakedModel getHeldItemModelMixin(BakedModel bakedModel, @Local(argsOnly = true) ItemStack stack) {
-        ItemRenderingCodec itemRenderingCodec = ItemRenderingLoader.REGISTRY.getOrDefault(BuiltInRegistries.ITEM.getKey(stack.getItem()), null);
+        ItemRenderingCodec itemRenderingCodec = ItemRenderingLoader.get(BuiltInRegistries.ITEM.getKey(stack.getItem()));
 
         if (itemRenderingCodec != null) {
             return this.itemModelShaper.getModelManager().getModel(ModelResourceLocation.inventory(itemRenderingCodec.itemId_3d()));

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/mixin/client/ModeBakeryMixin.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/mixin/client/ModeBakeryMixin.java
@@ -17,7 +17,7 @@ public abstract class ModeBakeryMixin {
 
     @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/resources/model/ModelBakery;loadSpecialItemModelAndDependencies(Lnet/minecraft/client/resources/model/ModelResourceLocation;)V", ordinal = 1))
     private void onInit(CallbackInfo ci) {
-        for (ItemRenderingCodec itemRender : ItemRenderingLoader.REGISTRY.values()) {
+        for (ItemRenderingCodec itemRender : ItemRenderingLoader.entries()) {
             this.loadSpecialItemModelAndDependencies(ModelResourceLocation.inventory(itemRender.itemId()));
             this.loadSpecialItemModelAndDependencies(ModelResourceLocation.inventory(itemRender.itemId_3d()));
         }

--- a/common/src/main/java/com/github/yajatkaul/mega_showdown/render/ItemRenderingLoader.java
+++ b/common/src/main/java/com/github/yajatkaul/mega_showdown/render/ItemRenderingLoader.java
@@ -4,7 +4,6 @@ import com.github.yajatkaul.mega_showdown.MegaShowdown;
 import com.github.yajatkaul.mega_showdown.api.codec.item.ItemRenderingCodec;
 import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
-import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
@@ -14,39 +13,47 @@ import org.jetbrains.annotations.NotNull;
 import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 public class ItemRenderingLoader implements ResourceManagerReloadListener {
-    public static final HashMap<ResourceLocation, ItemRenderingCodec> REGISTRY = new HashMap<>();
+    private static volatile Map<ResourceLocation, ItemRenderingCodec> registry = Map.of();
     private static final String DIRECTORY = "item_rendering";
 
-    public static void load() {
-        ResourceManager rm = Minecraft.getInstance().getResourceManager();
+    public static ItemRenderingCodec get(ResourceLocation itemId) {
+        return registry.get(itemId);
+    }
 
-        REGISTRY.clear();
+    public static Collection<ItemRenderingCodec> entries() {
+        return registry.values();
+    }
+
+    private static void load(ResourceManager resourceManager) {
+        HashMap<ResourceLocation, ItemRenderingCodec> loadedRegistry = new HashMap<>();
 
         Collection<ResourceLocation> resources =
-                rm.listResources(DIRECTORY, path -> path.getPath().endsWith(".json")).keySet();
+                resourceManager.listResources(DIRECTORY, path -> path.getPath().endsWith(".json")).keySet();
 
         for (ResourceLocation id : resources) {
-            try (var stream = rm.getResource(id).get().open()) {
+            try (var stream = resourceManager.getResource(id).get().open()) {
                 ItemRenderingCodec codec = ItemRenderingCodec.CODEC.parse(
                         JsonOps.INSTANCE,
                         JsonParser.parseReader(new InputStreamReader(stream))
                 ).result().orElseThrow();
-                REGISTRY.put(codec.itemId(), codec);
+                loadedRegistry.put(codec.itemId(), codec);
             } catch (Exception e) {
                 MegaShowdown.LOGGER.error("Failed loading item_rendering JSON: {}", id, e);
             }
         }
 
-        MegaShowdown.LOGGER.info("Loaded {} custom rendering entries", REGISTRY.size());
+        registry = Map.copyOf(loadedRegistry);
+        MegaShowdown.LOGGER.info("Loaded {} custom rendering entries", registry.size());
     }
 
     @Override
     public @NotNull CompletableFuture<Void> reload(PreparationBarrier preparationBarrier, ResourceManager resourceManager, ProfilerFiller profilerFiller, ProfilerFiller profilerFiller2, Executor executor, Executor executor2) {
-        load();
+        load(resourceManager);
         return ResourceManagerReloadListener.super.reload(preparationBarrier, resourceManager, profilerFiller, profilerFiller2, executor, executor2);
     }
 


### PR DESCRIPTION
A ConcurrentModificationException can occur in-game while models are being baked during a resource reload.

This PR makes model baking use a stable registry snapshot, preventing concurrent updates from causing the crash.

<img width="1280" height="213" alt="photo_2026-07-23_03-29-39" src="https://github.com/user-attachments/assets/993fe93d-fb59-4d11-917a-66580cdc288c" />