### PR TITLE
Game-accurate Judgement with Legend Plate

### DIFF
--- a/common/src/main/resources/data/mega_showdown/mega_showdown/showdown/held_items/legendplate.js
+++ b/common/src/main/resources/data/mega_showdown/mega_showdown/showdown/held_items/legendplate.js
@@ -1,22 +1,119 @@
 {
-name: "Legend Plate",
-    onTryMove(p, t, m) {
-      if (!(p.hasItem('legendplate') && m.id === 'judgment')) return;
-      const tt = t.getTypes().length ? t.getTypes() : t.species.types, tn = this.dex.types.names();
-      let bt = [], hs = -Infinity;
-      for (const at of tn) {
-        if (tt.some(dt => !this.dex.getImmunity(at, dt))) continue;
-        const s = tt.reduce((a, dt) => a + (e = this.dex.getEffectiveness(at, dt), e === 2 ? 4 : e === 1 ? 2 : e === -1 ? -1 : e === -2 ? -2 : 0), 0);
-        if (s > hs) bt = [at], hs = s;
-        else if (s === hs) bt.push(at);
+  name: "Legend Plate",
+  onTryMove(pokemon, target, move) {
+    if (pokemon.name !== "Arceus" || move.id !== "judgment" || !pokemon.hasItem("legendplate")) {
+      return;
+    }
+
+    function getForme(type) {
+      const forme = `Arceus-${type}`;
+      const species = this.dex.species.get(`arceus${type.toLowerCase()}`);
+      if (species.exists && this.dex.species.get(forme).exists) {
+        return forme;
       }
-      const btFinal = bt.includes('Normal') ? 'Normal' : this.sample(bt);
-      if (p.name !== 'Arceus') return;
-      const f = `Arceus-${btFinal}`, sp = this.dex.species.get(`arceus${btFinal.toLowerCase()}`);
-      if (sp.exists && this.dex.species.get(f).exists && p.species.name !== f) p.formeChange(f, null, true);
-      m.type = btFinal, m.ignoreAbility = true;
-    },
-	onTakeItem: false,
-    num: 2000,
-    gen: 9,
-  }
+      return null;
+    }
+
+    function targetVisualTypes() {
+      if (target.terastallized) {
+        return [target.terastallized];
+      } else if (target.illusion) {
+        /* Ignores type-altering effects such as Soak */
+        /* Consistent with in-game UI */
+        return target.illusion.species.types;
+      } else {
+        return target.getTypes();
+      }
+    }
+    const seenTypes = targetVisualTypes();
+
+    /**
+     * @param {string} attack
+     * @param {string[] | string} defend
+     * @returns {number} 0 neutral, +1 for each effective, -1 for each resist, -Infinity for immunity
+     */
+    function computeEffectiveness(attack, defend) {
+      return !this.dex.getImmunity(attack, defend) ? -Infinity : this.dex.getEffectiveness(attack, defend);
+    }
+
+    /**
+     * Returns the attacking types with the best effectiveness against the defending types
+     * @param {string[]} attackTypes
+     * @param {string[] | string} defend
+     * @returns {string[]}
+     */
+    function mostEffectiveTypes(attackTypes, defend) {
+      let best = [];
+      let bestEffectiveness = undefined;
+      for (const attackType of attackTypes) {
+        const effectiveness = computeEffectiveness.call(this, attackType, defend);
+        if (bestEffectiveness === undefined || effectiveness > bestEffectiveness) {
+          bestEffectiveness = effectiveness;
+          best = [attackType];
+        } else if (effectiveness === bestEffectiveness) {
+          best.push(attackType);
+        }
+      }
+      return best;
+    }
+
+    /**
+     * Returns the defending types with the best resistance against the attack type
+     * @param {string} attackType
+     * @param {string[]} defendTypes
+     * @returns {string[]}
+     */
+    function mostResistantTypes(attackType, defendTypes) {
+      let best = [];
+      let bestEffectiveness = undefined;
+      for (const defendType of defendTypes) {
+        const effectiveness = computeEffectiveness.call(this, attackType, defendType);
+        if (bestEffectiveness === undefined || effectiveness < bestEffectiveness) {
+          bestEffectiveness = effectiveness;
+          best = [defendType];
+        } else if (effectiveness === bestEffectiveness) {
+          best.push(defendType);
+        }
+      }
+      return best;
+    }
+
+    function computeJudgementType() {
+      if (seenTypes.length === 0) {
+        return "Normal";
+      }
+
+      /* 1. Choose the type that has the best effectiveness against the target */
+      const possibleTypes = this.dex.types.names().filter(type => getForme.call(this, type) !== null);
+      let bestTypes = mostEffectiveTypes.call(this, possibleTypes, seenTypes);
+      if (bestTypes.length === 1) {
+        return bestTypes[0];
+      }
+
+      /* 2. If tie, choose the type that best resists the target's primary type, then the target's secondary type, then tertiary type */
+      for (const toResist of seenTypes) {
+        const newBestTypes = mostResistantTypes.call(this, toResist, bestTypes);
+        if (newBestTypes.length === 1) {
+          return newBestTypes[0];
+        }
+        bestTypes = newBestTypes;
+      }
+
+      /* 3. If tie, choose randomly */
+      if (bestTypes.length === 0) {
+        return "Normal";
+      }
+      return this.sample(bestTypes);
+    }
+
+    const judgementType = computeJudgementType.call(this);
+    const forme = getForme.call(this, judgementType);
+    if (forme !== null && pokemon.species.name !== forme) {
+      pokemon.formeChange(forme, null, true);
+    }
+    move.type = judgementType;
+  },
+  onTakeItem: false,
+  num: 2000,
+  gen: 9,
+}


### PR DESCRIPTION
Reworks the Legend Plate to 100% match its behavior in [Legends: Arceus](https://bulbapedia.bulbagarden.net/wiki/Judgment_(move)), while implementing a best estimate of how the Legend Plate would work if it was ported to a mainline game with abilities and type modifications.

1. Judgement becomes the type that is most effective based on the target's types (as long as Arceus has a forme of that type).
2. If multiple types are equally effective, Judgement will become the type that best resists the target's primary type. If multiple types are equally resistant, Judgement will become the type that best resists the target's secondary type, then tertiary type.
3. If multiple types are still valid, Judgement will pick one at random.

Judgement will calculate its type based on the target's *apparent types* (the types that appear in the move selection UI):

- Judgement considers changes to the target's type (such as from Terastallization, Burn Up, Soak, or Trick-or-Treat) when calculating what type to use, but not other conditions that modify effectiveness (such as Levitate or Tar Shot).
- If the target is disguised with Illusion, Judgement will act as if the target has the types of the pokemon it is disguised as, [even if that type is later modified](https://bulbapedia.bulbagarden.net/wiki/Illusion_(Ability)#In_battle).
- If the opponent is typeless, Judgement will be Normal-type.

Lastly, Judgement no longer bypasses abilities to be consistent with Judgement without the Legend Plate.