### PR TITLE
Fixed Aegislash blade forme in Pokédex

### DIFF
--- a/common/src/main/resources/assets/cobblemon/bedrock/pokemon/posers/0681_aegislash/aegislash_blade2.json
+++ b/common/src/main/resources/assets/cobblemon/bedrock/pokemon/posers/0681_aegislash/aegislash_blade2.json
@@ -1,47 +1,42 @@
 {
   "portraitScale": 1.99,
-  "portraitTranslation": [
-    -0.27,
-    2.29,
-    0
-  ],
+  "portraitTranslation": [-0.27, 2.29, 0],
   "profileScale": 0.56,
-  "profileTranslation": [
-    0,
-    1.2,
-    0
-  ],
+  "profileTranslation": [0, 1.2, 0],
   "animations": {
     "cry": "q.bedrock_stateful('aegislash', 'cry')"
   },
   "poses": {
-    "standing": {
-      "poseTypes": [
-        "STAND",
-        "NONE",
-        "PORTRAIT",
-        "PROFILE",
-        "FLOAT",
-        "HOVER"
+    "portrait": {
+      "poseTypes": ["PORTRAIT"],
+      "animations": [
+        "q.look('body')", 
+        "q.bedrock('aegislash', 'blade_forme')"
       ],
+      "quirks": ["q.bedrock_quirk('aegislash', 'blink')"]
+    }, 
+    "profile": {
+      "poseTypes": ["PROFILE"],
+      "animations": [
+        "q.look('body')", 
+        "q.bedrock('aegislash', 'blade_forme')"
+      ],
+      "quirks": ["q.bedrock_quirk('aegislash', 'blink')"]
+    },
+    "standing": {
+      "poseTypes": ["STAND", "NONE", "FLOAT", "HOVER"],
       "isBattle": false,
       "animations": [
-        "q.look('body')",
-        "q.bedrock('aegislash', 'ground_idle')"
+        "q.look('body')", 
+        "q.bedrock('aegislash', 'battle_idle')"
       ],
-      "quirks": [
-        "q.bedrock_quirk('aegislash', 'blink')"
-      ]
+      "quirks": ["q.bedrock_quirk('aegislash', 'blink')"]
     },
     "battle-standing": {
-      "poseTypes": [
-        "STAND",
-        "FLOAT",
-        "HOVER"
-      ],
+      "poseTypes": ["STAND","FLOAT","HOVER"],
       "isBattle": true,
       "animations": [
-        "q.look('head')",
+        "q.look('body')",
         "q.bedrock('aegislash', 'blade_forme')"
       ],
       "quirks": [
@@ -49,11 +44,7 @@
       ]
     },
     "walking": {
-      "poseTypes": [
-        "WALK",
-        "SWIM",
-        "FLY"
-      ],
+      "poseTypes": ["WALK", "SWIM", "FLY"],
       "animations": [
         "q.look('body')",
         "q.bedrock('aegislash', 'ground_walk')"
@@ -63,12 +54,8 @@
       ]
     },
     "sleep": {
-      "poseTypes": [
-        "SLEEP"
-      ],
-      "animations": [
-        "q.bedrock('aegislash', 'sleep')"
-      ]
+      "poseTypes": ["SLEEP"],
+      "animations": ["q.bedrock('aegislash', 'sleep')"]
     }
   }
 }


### PR DESCRIPTION
Blade forme appeared as shield forme in the Pokédex, this fixes it
<img width="562" height="324" alt="image" src="https://github.com/user-attachments/assets/4eb20e2e-52be-493d-a141-de1b8827459f" />
