### PR TITLE
Cobblemon requirement & spelling fixes

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "id": "mega_showdown",
   "version": "${version}",
-  "name": "Cobblemon:Mega Showdown",
-  "description": "Adding mega evolutions, z-moves, teralization, dynamax, ultra burst and fusions to the game\nFeatures\n- Cosmetics\n- All form changes\n- Ridding supported\n- All 48 megas\n- Accessories support\n- Adds primal's\n- Adds tera gimmik\n- Adds mega gimmik\n- Adds z moves gimmik\n- Adds dynamax gimmik\n- Adds ultra burst gimmik\n- All fusion mons",
+  "name": "Cobblemon: Mega Showdown",
+  "description":  "Adds Mega Evolutions, Z-Moves, Teralization, Dyna/Gigantamax, Ultra Burst and fusions to the game!\nFeatures:\n- Adds every Pokémon & form related to gimmicks (megas, form changes, gmax, fusions etc.) & many legendary models\n- Riding supported for many of them\n- Accessories support",
   "authors": [
     "YajatKaul"
   ],
@@ -36,7 +36,7 @@
     "java": ">=21",
     "architectury": ">=13.0.8",
     "fabric-api": "*",
-    "cobblemon": ">=1.7.3",
+    "cobblemon": ">=1.8.0",
     "accessories": ">=1.1.0-beta.52+1.21.1"
   }
 }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -6,23 +6,14 @@ license = "MEGA SHOWDOWN LICENSE v2.1"
 [[mods]]
 modId = "mega_showdown"
 version = "${version}"
-displayName = "Cobblemon:Mega Showdown"
+displayName = "Cobblemon: Mega Showdown"
 authors = "Yajat Kaul"
 description = '''
-Adding mega evolutions, z-moves, teralization, dynamax, ultra burst and fusions to the game
-Features
-- Cosmetics
-- All form changes
-- Ridding supported
-- All 48 megas
+Adds Mega Evolutions, Z-Moves, Teralization, Dyna/Gigantamax, Ultra Burst and fusions to the game!
+Features:
+- Adds every Pokémon & form related to gimmicks (megas, form changes, gmax, fusions etc.) & many legendary models
+- Riding supported for many of them
 - Accessories support
-- Adds primal's
-- Adds tera gimmik
-- Adds mega gimmik
-- Adds z moves gimmik
-- Adds dynamax gimmik
-- Adds ultra burst gimmik
-- All fusion mons
 '''
 logoFile = "assets/mega_showdown/icon.png"
 
@@ -50,7 +41,7 @@ side = "BOTH"
 [[dependencies.mega_showdown]]
 modId = "cobblemon"
 type = "required"
-versionRange = "[1.7.3, )"
+versionRange = "[1.8.0, )"
 ordering = "AFTER"
 side = "BOTH"
 


### PR DESCRIPTION
- Fixed the Cobblemon requirement still being `1.7.3` instead of `1.8.0`
- Fixed spelling mistakes in the mod description & removed unnecessary clutter/duplicates
- Changed the shown name from `Cobblemon:Mega Showdown` to `Cobblemon: Mega Showdown` (literally just added a space don't judge me)